### PR TITLE
Numbers as strings and customize the input field

### DIFF
--- a/src/MathCaptcha.php
+++ b/src/MathCaptcha.php
@@ -31,8 +31,8 @@ class MathCaptcha
     public function label()
     {
         if(config('math-captcha.text')) {
-            return sprintf("%s %s %s", lang('math-captcha.numbers.' . $this->getMathSecondOperator()), 
-            lang('math-captcha.operands.' . $this->getMathOperand()), lang('math-captcha.numbers.' . $this->getMathFirstOperator()));
+            return sprintf("%s %s %s", trans('math-captcha.numbers.' . $this->getMathSecondOperator()), 
+            trans('math-captcha.operands.' . $this->getMathOperand()), trans('math-captcha.numbers.' . $this->getMathFirstOperator()));
         } else {
             return sprintf("%d %s %d", $this->getMathSecondOperator(), $this->getMathOperand(), $this->getMathFirstOperator());
         }

--- a/src/MathCaptcha.php
+++ b/src/MathCaptcha.php
@@ -30,7 +30,12 @@ class MathCaptcha
      */
     public function label()
     {
-        return sprintf("%d %s %d", $this->getMathSecondOperator(), $this->getMathOperand(), $this->getMathFirstOperator());
+        if(config('math-captcha.text')) {
+            return sprintf("%s %s %s", lang('math-captcha.numbers.' . $this->getMathSecondOperator()), 
+            lang('math-captcha.operands.' . $this->getMathOperand()), lang('math-captcha.numbers.' . $this->getMathFirstOperator()));
+        } else {
+            return sprintf("%d %s %d", $this->getMathSecondOperator(), $this->getMathOperand(), $this->getMathFirstOperator());
+        }
     }
 
     /**
@@ -40,13 +45,16 @@ class MathCaptcha
      */
     public function input(array $attributes = [])
     {
-        $attributes['type'] = 'text';
-        $attributes['id'] = 'mathcaptcha';
-        $attributes['name'] = 'mathcaptcha';
-        $attributes['required'] = 'required';
-        $attributes['value'] = old('mathcaptcha');
+        $default = [];
+        $default['type'] = 'text';
+        $default['id'] = 'mathcaptcha';
+        $default['name'] = 'mathcaptcha';
+        $default['required'] = 'required';
+        $default['value'] = old('mathcaptcha');
 
-        $html = '<input ' . $this->buildAttributes($attributes) . ' />';
+        $attributes = array_merge($default, $attributes);
+
+        $html = '<input ' . $this->buildAttributes($attributes) . '>';
 
         return $html;
     }

--- a/src/MathCaptcha.php
+++ b/src/MathCaptcha.php
@@ -31,8 +31,11 @@ class MathCaptcha
     public function label()
     {
         if(config('math-captcha.text')) {
-            return sprintf("%s %s %s", trans('math-captcha.numbers.' . $this->getMathSecondOperator()), 
-            trans('math-captcha.operands.' . $this->getMathOperand()), trans('math-captcha.numbers.' . $this->getMathFirstOperator()));
+            return sprintf("%s %s %s",
+                trans('mathcaptcha::math-captcha.numbers.' . $this->getMathSecondOperator()), 
+                trans('mathcaptcha::math-captcha.operands.' . $this->getMathOperand()),
+                trans('mathcaptcha::math-captcha.numbers.' . $this->getMathFirstOperator())
+            );
         } else {
             return sprintf("%d %s %d", $this->getMathSecondOperator(), $this->getMathOperand(), $this->getMathFirstOperator());
         }

--- a/src/MathCaptchaServiceProvider.php
+++ b/src/MathCaptchaServiceProvider.php
@@ -20,6 +20,11 @@ class MathCaptchaServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/config' => config_path(),
         ], 'config');
+
+        $this->loadTranslationsFrom(__DIR__. '/resources/lang', 'mathcaptcha');
+        $this->publishes([
+            __DIR__ . '/resources/lang' => resource_path('lang/vendor/mathcaptcha'),
+        ], 'lang');
     }
 
     /**

--- a/src/config/math-captcha.php
+++ b/src/config/math-captcha.php
@@ -23,4 +23,9 @@ return [
      */
     'rand-max' => 5,
 
+    /**
+     * Use text instead of numbers
+     */
+    'text' => true,
+
 ];

--- a/src/resources/lang/en/math-captcha.php
+++ b/src/resources/lang/en/math-captcha.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+	'numbers' => [
+    '0' => 'Zero',
+    '1' => 'One',
+    '2' => 'Two',
+    '3' => 'Three',
+    '4' => 'Four',
+    '5' => 'Five',
+    '6' => 'Six',
+    '7' => 'Seven',
+    '8' => 'Eight',
+    '9' => 'Nine',
+    '10' => 'Ten',
+    '11' => 'Eleven',
+    '12' => 'Twelve',
+  ],
+  'operators' => [
+    '+' => 'Plus',
+    '-' => 'Minus',
+    '*' => 'Times',
+    '/' => 'Divided by',
+  ],
+];

--- a/src/resources/lang/sv/math-captcha.php
+++ b/src/resources/lang/sv/math-captcha.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+	'numbers' => [
+    '0' => 'Noll',
+    '1' => 'Ett',
+    '2' => 'Två',
+    '3' => 'Tre',
+    '4' => 'Fyra',
+    '5' => 'Fem',
+    '6' => 'Sex',
+    '7' => 'Sju',
+    '8' => 'Åtta',
+    '9' => 'Nio',
+    '10' => 'Tio',
+    '11' => 'Elva',
+    '12' => 'Tolv',
+  ],
+  'operands' => [
+    '+' => 'Plus',
+    '-' => 'Minus',
+    '*' => 'Gånger',
+    '/' => 'Delat med',
+  ],
+];


### PR DESCRIPTION
Make it harder for bots with translation from numbers and operators to strings. This is configurable.
Also make it possible for the user to customize the parameters for the input field.